### PR TITLE
Cannot use max_results in function list_tables()

### DIFF
--- a/R/tables.r
+++ b/R/tables.r
@@ -12,6 +12,7 @@
 #' \donttest{
 #' list_tables("publicdata", "samples")
 #' list_tables("githubarchive", "github")
+#' list_tables("publicdata", "samples", max_results = 2)
 #' }
 list_tables <- function(project, dataset, max_results = NULL) {
   assert_that(is.string(project), is.string(dataset))
@@ -20,10 +21,11 @@ list_tables <- function(project, dataset, max_results = NULL) {
   }
 
   url <- sprintf("projects/%s/datasets/%s/tables", project, dataset)
+  query <- list()
   if (!is.null(max_results)) {
-    url <- httr::modify_url(url, query = list(maxResults = max_results))
+    query$maxResults <- max_results
   }
-  data <- bq_get(url)$tables
+  data <- bq_get(url, query = query)$tables
   do.call("rbind", lapply(data, as.data.frame, row.names = 1L))
 
   unlist(lapply(data, function(x) x$tableReference$tableId))


### PR DESCRIPTION
When there are many tables in the dataset, I cannot retrieve a full list of them without option max_results. But after I added this parameter, got this error:

```
> histTxnTables <- list_tables(bqdaproject, bqBaseDataset)
Auto-refreshing stale OAuth token.
> histTxnTables <- list_tables(bqdaproject, bqBaseDataset, 1000)
Error: HTTP error [404] Not Found
```