### PR TITLE
Add support for reading API keys from an env var.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,3 @@
 # Version 0.1.0.9000
 
+* Add support for API keys via the `BIGRQUERY_API_KEY` environment variable. (#49)

--- a/R/request.r
+++ b/R/request.r
@@ -1,30 +1,44 @@
 base_url <- "https://www.googleapis.com/bigquery/v2/"
 upload_url <- "https://www.googleapis.com/upload/bigquery/v2/"
 
+prepare_bq_query <- function(query) {
+  api_key <- Sys.getenv("BIGRQUERY_API_KEY")
+  if (!nzchar(api_key)) {
+    return(query)
+  }
+  query <- query %||% list()
+  query[["key"]] <- query[["key"]] %||% api_key
+  query
+}
+
 #' @importFrom httr GET config
-bq_get <- function(url, ..., token = get_access_cred()) {
-  req <- GET(paste0(base_url, url), config(token = token), ...)
+bq_get <- function(url, ..., query = NULL, token = get_access_cred()) {
+  req <- GET(paste0(base_url, url), config(token = token), ...,
+             query = prepare_bq_query(query))
   process_request(req)
 }
 
 #' @importFrom httr DELETE config
-bq_delete <- function(url, ..., token = get_access_cred()) {
-  req <- DELETE(paste0(base_url, url), config(token = token), ...)
+bq_delete <- function(url, ..., query = NULL, token = get_access_cred()) {
+  req <- DELETE(paste0(base_url, url), config(token = token), ...,
+                query = prepare_bq_query(query))
   process_request(req)
 }
 
 #' @importFrom httr POST add_headers config
-bq_post <- function(url, body, ..., token = get_access_cred()) {
+bq_post <- function(url, body, ..., query = NULL, token = get_access_cred()) {
   json <- jsonlite::toJSON(body)
   req <- POST(paste0(base_url, url), body = json, config(token = token),
-    add_headers("Content-Type" = "application/json"), ...)
+              add_headers("Content-Type" = "application/json"), ...,
+              query = prepare_bq_query(query))
   process_request(req)
 }
 
 #' @importFrom httr POST add_headers config
-bq_upload <- function(url, parts, ..., token = get_access_cred()) {
+bq_upload <- function(url, parts, ..., query = NULL, token = get_access_cred()) {
   url <- paste0(upload_url, url)
-  req <- POST_multipart_related(url, parts = parts, config(token = token), ...)
+  req <- POST_multipart_related(url, parts = parts, config(token = token), ...,
+                                query = prepare_bq_query(query))
   process_request(req)
 }
 

--- a/tests/testthat/test-request.r
+++ b/tests/testthat/test-request.r
@@ -1,0 +1,24 @@
+context("request")
+
+test_that("api keys are added when present", {
+  tryCatch({
+    key <- 'my.secret.key'
+    Sys.setenv(BIGRQUERY_API_KEY = key)
+    expect_that(bigrquery:::prepare_bq_query(NULL), equals(list(key = key)))
+    expect_that(bigrquery:::prepare_bq_query(list(herring_color = "red")),
+                equals(list(herring_color = "red", key = key)))
+  }, finally = {
+    Sys.unsetenv("BIGRQUERY_API_KEY")
+  })
+})
+
+test_that("explicit api keys override env vars", {
+  tryCatch({
+    key <- 'my.secret.key'
+    Sys.setenv(BIGRQUERY_API_KEY = key)
+    expect_that(bigrquery:::prepare_bq_query(list(key = "my.other.key")),
+                equals(list(key = "my.other.key")))
+  }, finally = {
+    Sys.unsetenv("BIGRQUERY_API_KEY")
+  })
+})


### PR DESCRIPTION
This adds support for API keys to bigrquery, reading them from the
`BIGRQUERY_API_KEY` environment variable. They're used in all API calls when
present.

PTAL @hadley 